### PR TITLE
activate venv for pdoc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,5 +10,6 @@ setup: # set up virtual environment and install dependencies
 	pip3 install -r requirements.txt
 
 docs: # browse docs
+	source venv/bin/activate && \
 	pdoc *.py
 


### PR DESCRIPTION
This PR enables the venv for `make docs`. 

If the venv wasn't already active, `pdoc` would otherwise need to be globally installed.
